### PR TITLE
Mostly style changes to chapter 2 examples

### DIFF
--- a/chp02_forces/NOC_2_1_forces/mover.js
+++ b/chp02_forces/NOC_2_1_forces/mover.js
@@ -2,15 +2,15 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Mover() {
+var Mover = function() {
     this.mass = 1;
-    this.position = new PVector(30,30);
-    this.velocity = new PVector(0,0);
-    this.acceleration = new PVector(0,0);
-}
+    this.position = new PVector(30, 30);
+    this.velocity = new PVector(0, 0);
+    this.acceleration = new PVector(0, 0);
+};
   
 Mover.prototype.applyForce = function(force) {
-  var f = PVector.div(force,this.mass);
+  var f = PVector.div(force, this.mass);
   this.acceleration.add(f);
 };
   
@@ -23,8 +23,8 @@ Mover.prototype.update = function() {
 Mover.prototype.display = function() {
   stroke(0);
   strokeWeight(2);
-  fill(255,127);
-  ellipse(this.position.x,this.position.y,48,48);
+  fill(255, 127);
+  ellipse(this.position.x, this.position.y, 48, 48);
 };
 
 Mover.prototype.checkEdges = function() {

--- a/chp02_forces/NOC_2_1_forces/sketch.js
+++ b/chp02_forces/NOC_2_1_forces/sketch.js
@@ -5,15 +5,15 @@
 var m;
 
 function setup() {
-  createGraphics(640,360);
-  m = new Mover(); 
+  createGraphics(640, 360);
+  m = new Mover();
 }
 
 function draw() {
   background(51);
 
-  var wind = new PVector(0.01,0);
-  var gravity = new PVector(0,0.1);
+  var wind = new PVector(0.01, 0);
+  var gravity = new PVector(0, 0.1);
   m.applyForce(wind);
   m.applyForce(gravity);
 
@@ -22,7 +22,7 @@ function draw() {
   m.display();
   m.checkEdges();
 
-};
+}
 
 
 

--- a/chp02_forces/NOC_2_2_forces_many/mover.js
+++ b/chp02_forces/NOC_2_2_forces_many/mover.js
@@ -2,15 +2,15 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Mover(m,x,y) {
+var Mover = function(m, x, y) {
     this.mass = m;
-    this.position = new PVector(x,y);
-    this.velocity = new PVector(0,0);
-    this.acceleration = new PVector(0,0);
-}
+    this.position = new PVector(x, y);
+    this.velocity = new PVector(0, 0);
+    this.acceleration = new PVector(0, 0);
+};
   
 Mover.prototype.applyForce = function(force) {
-  var f = PVector.div(force,this.mass);
+  var f = PVector.div(force, this.mass);
   this.acceleration.add(f);
 };
   
@@ -23,8 +23,8 @@ Mover.prototype.update = function() {
 Mover.prototype.display = function() {
   stroke(0);
   strokeWeight(2);
-  fill(255,127);
-  ellipse(this.position.x,this.position.y,this.mass*16,this.mass*16);
+  fill(255, 127);
+  ellipse(this.position.x, this.position.y, this.mass*16, this.mass*16);
 };
 
 Mover.prototype.checkEdges = function() {

--- a/chp02_forces/NOC_2_2_forces_many/sketch.js
+++ b/chp02_forces/NOC_2_2_forces_many/sketch.js
@@ -5,9 +5,9 @@
 var movers = [];
 
 function setup() {
-  createGraphics(640,360);
+  createGraphics(640, 360);
   for (var i = 0; i < 20; i++) {
-    movers[i] = new Mover(random(0.1,4),0,0); 
+    movers[i] = new Mover(random(0.1, 5), 0, 0);
   }
 }
 
@@ -15,15 +15,15 @@ function draw() {
   background(51);
   
   for (var i = 0; i < movers.length; i++) {
-    var wind = new PVector(0.01,0);
-    var gravity = new PVector(0,0.1);
+    var wind = new PVector(0.01, 0);
+    var gravity = new PVector(0, 0.1);
     movers[i].applyForce(wind);
     movers[i].applyForce(gravity);
     movers[i].update();
     movers[i].display();
     movers[i].checkEdges();
   }
-};
+}
 
 
 

--- a/chp02_forces/NOC_2_4_forces_friction/mover.js
+++ b/chp02_forces/NOC_2_4_forces_friction/mover.js
@@ -2,15 +2,15 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Mover(m,x,y) {
-    this.mass = m;
-    this.position = new PVector(x,y);
-    this.velocity = new PVector(0,0);
-    this.acceleration = new PVector(0,0);
-}
+var Mover = function(m, x, y) {
+  this.mass = m;
+  this.position = new PVector(x, y);
+  this.velocity = new PVector(0, 0);
+  this.acceleration = new PVector(0, 0);
+};
   
 Mover.prototype.applyForce = function(force) {
-  var f = PVector.div(force,this.mass);
+  var f = PVector.div(force, this.mass);
   this.acceleration.add(f);
 };
   
@@ -23,8 +23,8 @@ Mover.prototype.update = function() {
 Mover.prototype.display = function() {
   stroke(0);
   strokeWeight(2);
-  fill(255,127);
-  ellipse(this.position.x,this.position.y,this.mass*16,this.mass*16);
+  fill(255, 127);
+  ellipse(this.position.x, this.position.y, this.mass*16, this.mass*16);
 };
 
 Mover.prototype.checkEdges = function() {

--- a/chp02_forces/NOC_2_4_forces_friction/sketch.js
+++ b/chp02_forces/NOC_2_4_forces_friction/sketch.js
@@ -5,9 +5,9 @@
 var movers = [];
 
 function setup() {
-  createGraphics(640,360);
+  createGraphics(640, 360);
   for (var i = 0; i < 20; i++) {
-    movers[i] = new Mover(random(1,4),random(width),0); 
+    movers[i] = new Mover(random(1, 4), random(width), 0);
   }
 }
 
@@ -15,14 +15,16 @@ function draw() {
   background(51);
   
   for (var i = 0; i < movers.length; i++) {
-    var wind = new PVector(0.01,0);
+    var wind = new PVector(0.01, 0);
     var gravity = new PVector(0, 0.1*movers[i].mass);
 
-    var c = 0.05;
+    var c = 0.01;
+    var normal = 1;
+    var frictionMag = c * normal;
     var friction = movers[i].velocity.get();
-    friction.mult(-1); 
+    friction.mult(-1);
     friction.normalize();
-    friction.mult(c);
+    friction.mult(frictionMag);
 
 
     movers[i].applyForce(friction);
@@ -32,4 +34,4 @@ function draw() {
     movers[i].display();
     movers[i].checkEdges();
   }
-};
+}

--- a/chp02_forces/NOC_2_5_fluidresistance/liquid.js
+++ b/chp02_forces/NOC_2_5_fluidresistance/liquid.js
@@ -2,22 +2,23 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Liquid(x_, y_, w_, h_, c_) {
-  this.x = x_;
-  this.y = y_;
-  this.w = w_;
-  this.h = h_;
-  this.c = c_;
+var Liquid = function(x, y, w, h, c) {
+  this.x = x;
+  this.y = y;
+  this.w = w;
+  this.h = h;
+  this.c = c;
 };
   
-  // Is the Mover in the Liquid?
+// Is the Mover in the Liquid?
 Liquid.prototype.contains = function(m) {
   var l = m.position;
-  return l.x > this.x && l.x < this.x + this.w && l.y > this.y && l.y < this.y + this.h;
+  return l.x > this.x && l.x < this.x + this.w &&
+         l.y > this.y && l.y < this.y + this.h;
 };
   
-  // Calculate drag force
-Liquid.prototype.drag = function(m) {
+// Calculate drag force
+Liquid.prototype.calculateDrag = function(m) {
   // Magnitude is coefficient * speed squared
   var speed = m.velocity.mag();
   var dragMagnitude = this.c * speed * speed;
@@ -35,6 +36,6 @@ Liquid.prototype.drag = function(m) {
   
 Liquid.prototype.display = function() {
   noStroke();
-  fill(51);
-  rect(this.x,this.y,this.w,this.h);
+  fill(50);
+  rect(this.x, this.y, this.w, this.h);
 };

--- a/chp02_forces/NOC_2_5_fluidresistance/sketch.js
+++ b/chp02_forces/NOC_2_5_fluidresistance/sketch.js
@@ -19,7 +19,7 @@ function setup() {
   reset();
   // Create liquid object
   liquid = new Liquid(0, height/2, width, height/2, 0.1);
-};
+}
 
 function draw() {
   background(127);
@@ -32,7 +32,7 @@ function draw() {
     // Is the Mover in the liquid?
     if (liquid.contains(movers[i])) {
       // Calculate drag force
-      var dragForce = liquid.drag(movers[i]);
+      var dragForce = liquid.calculateDrag(movers[i]);
       // Apply drag force to Mover
       movers[i].applyForce(dragForce);
     }
@@ -49,22 +49,22 @@ function draw() {
   }
   
   fill(255); // Fill not working for text?
-  text("click mouse to reset",10,30);
+  text("click mouse to reset", 10, 30);
   
-};
+}
 
 
 // Not working???
 function mousePressed() {
   reset();
-};
+}
 
 // Restart all the Mover objects randomly
 function reset() {
   for (var i = 0; i < 9; i++) {
     movers[i] = new Mover(random(0.5, 3), 40+i*70, 0);
   }
-};
+}
 
 
 

--- a/chp02_forces/NOC_2_6_attraction/attractor.js
+++ b/chp02_forces/NOC_2_6_attraction/attractor.js
@@ -2,64 +2,74 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-// A class for a draggable attractive body in our world
+// An object for a draggable attractive body in our world
 
-function Attractor() {
-  this.position = new PVector(width/2,height/2);
+var Attractor = function() {
+  this.position = new PVector(width/2, height/2);
   this.mass = 20;
   this.G = 1;
-  this.dragOffset = new PVector(0,0);
+  this.dragOffset = new PVector(0, 0);
   this.dragging = false;
   this.rollover = false;
 };
 
-Attractor.prototype.attract = function(m) {
-  var force = PVector.sub(this.position,m.position);       // Calculate direction of force
-  var d = force.mag();                                     // Distance between objects
-  d = constrain(d,5,25);                                   // Limiting the distance to eliminate "extreme" results for very close or very far objects
-  force.normalize();                                       // Normalize vector (distance doesn't matter here, we just want this vector for direction)
-  var strength = (this.G * this.mass * m.mass) / (d * d);  // Calculate gravitional force magnitude
-  force.mult(strength);                                    // Get force vector --> magnitude * direction
+Attractor.prototype.calculateAttraction = function(m) {
+  // Calculate direction of force
+  var force = PVector.sub(this.position, m.position);
+  // Distance between objects       
+  var distance = force.mag();
+  // Limiting the distance to eliminate "extreme" results for very close or very far objects                            
+  distance = constrain(distance, 5, 25);
+  // Normalize vector (distance doesn't matter here, we just want this vector for direction)                                  
+  force.normalize();
+  // Calculate gravitional force magnitude  
+  var strength = (this.G * this.mass * m.mass) / (distance * distance);
+  // Get force vector --> magnitude * direction
+  force.mult(strength);
   return force;
-}
+};
 
 // Method to display
 Attractor.prototype.display = function() {
   ellipseMode(CENTER);
   strokeWeight(4);
   stroke(0);
-  if (this.dragging) fill(50);
-  else if (this.rollover) fill(100);
-  else fill(175,200);
-  ellipse(this.position.x,this.position.y,this.mass*2,this.mass*2);
-}
+  if (this.dragging) {
+    fill(50);
+  } else if (this.rollover) {
+    fill(100);
+  } else {
+    fill(175, 200);
+  }
+  ellipse(this.position.x, this.position.y, this.mass*2, this.mass*2);
+};
 
   // The methods below are for mouse interaction
-Attractor.prototype.clicked = function(mx, my) {
-  var d = dist(mx,my,this.position.x,this.position.y);
+Attractor.prototype.handleClick = function(mx, my) {
+  var d = dist(mx, my, this.position.x, this.position.y);
   if (d < this.mass) {
     this.dragging = true;
-    this.dragOffset.x = this.position.x-mx;
-    this.dragOffset.y = this.position.y-my;
+    this.dragOffset.x = this.position.x - mx;
+    this.dragOffset.y = this.position.y - my;
   }
-}
+};
 
-Attractor.prototype.hover = function(mx, my) {
-  var d = dist(mx,my,this.position.x,this.position.y);
+Attractor.prototype.handleHover = function(mx, my) {
+  var d = dist(mx, my, this.position.x, this.position.y);
   if (d < this.mass) {
     this.rollover = true;
   } else {
     this.rollover = false;
   }
-}
+};
 
 Attractor.prototype.stopDragging = function() {
   this.dragging = false;
-}
+};
 
-Attractor.prototype.drag = function() {
+Attractor.prototype.handleDrag = function(mx, my) {
   if (this.dragging) {
-    this.position.x = mouseX + this.dragOffset.x;
-    this.position.y = mouseY + this.dragOffset.y;
+    this.position.x = mx + this.dragOffset.x;
+    this.position.y = my + this.dragOffset.y;
   }
-}
+};

--- a/chp02_forces/NOC_2_6_attraction/mover.js
+++ b/chp02_forces/NOC_2_6_attraction/mover.js
@@ -2,12 +2,12 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Mover() {
-  this.position = new PVector(400,50);
-  this.velocity = new PVector(1,0);
-  this.acceleration = new PVector(0,0);
+var Mover = function() {
+  this.position = new PVector(400, 50);
+  this.velocity = new PVector(1, 0);
+  this.acceleration = new PVector(0, 0);
   this.mass = 1;
-}
+};
   
 Mover.prototype.applyForce = function(force) {
   var f = PVector.div(force,this.mass);
@@ -23,8 +23,8 @@ Mover.prototype.update = function() {
 Mover.prototype.display = function() {
   stroke(0);
   strokeWeight(2);
-  fill(255,127);
-  ellipse(this.position.x,this.position.y,this.mass*16,this.mass*16);
+  fill(255, 127);
+  ellipse(this.position.x, this.position.y, this.mass*16, this.mass*16);
 };
 
 Mover.prototype.checkEdges = function() {

--- a/chp02_forces/NOC_2_6_attraction/sketch.js
+++ b/chp02_forces/NOC_2_6_attraction/sketch.js
@@ -7,29 +7,35 @@ var mover;
 var attractor;
 
 function setup() {
-  createGraphics(640,360);
-  mover = new Mover(); 
+  createGraphics(640, 360);
+  mover = new Mover();
   attractor = new Attractor();
-};
+}
 
 function draw() {
   background(51);
 
-  var force = attractor.attract(mover);
+  var force = attractor.calculateAttraction(mover);
   mover.applyForce(force);
   mover.update();
   
-  attractor.drag();
-  attractor.hover(mouseX,mouseY);
- 
   attractor.display();
   mover.display();
-};
+}
+
+function mouseMoved() {
+  attractor.handleHover(mouseX, mouseY);
+}
 
 function mousePressed() {
-  attractor.clicked(mouseX, mouseY);
-};
+  attractor.handlePress(mouseX, mouseY);
+}
+
+function mouseDragged() {
+  attractor.handleHover(mouseX, mouseY);
+  attractor.handleDrag(mouseX, mouseY);
+}
 
 function mouseReleased() {
   attractor.stopDragging();
-};
+}

--- a/chp02_forces/NOC_2_7_attraction_many/attractor.js
+++ b/chp02_forces/NOC_2_7_attraction_many/attractor.js
@@ -2,64 +2,74 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-// A class for a draggable attractive body in our world
+// An object for a draggable attractive body in our world
 
-function Attractor() {
-  this.position = new PVector(width/2,height/2);
+var Attractor = function() {
+  this.position = new PVector(width/2, height/2);
   this.mass = 20;
   this.G = 1;
-  this.dragOffset = new PVector(0,0);
+  this.dragOffset = new PVector(0, 0);
   this.dragging = false;
   this.rollover = false;
 };
 
-Attractor.prototype.attract = function(m) {
-  var force = PVector.sub(this.position,m.position);       // Calculate direction of force
-  var d = force.mag();                                     // Distance between objects
-  d = constrain(d,5,25);                                   // Limiting the distance to eliminate "extreme" results for very close or very far objects
-  force.normalize();                                       // Normalize vector (distance doesn't matter here, we just want this vector for direction)
-  var strength = (this.G * this.mass * m.mass) / (d * d);  // Calculate gravitional force magnitude
-  force.mult(strength);                                    // Get force vector --> magnitude * direction
+Attractor.prototype.calculateAttraction = function(m) {
+  // Calculate direction of force
+  var force = PVector.sub(this.position, m.position);
+  // Distance between objects       
+  var distance = force.mag();
+  // Limiting the distance to eliminate "extreme" results for very close or very far objects                            
+  distance = constrain(distance, 5, 25);
+  // Normalize vector (distance doesn't matter here, we just want this vector for direction)                                  
+  force.normalize();
+  // Calculate gravitional force magnitude  
+  var strength = (this.G * this.mass * m.mass) / (distance * distance);
+  // Get force vector --> magnitude * direction
+  force.mult(strength);
   return force;
-}
+};
 
 // Method to display
 Attractor.prototype.display = function() {
   ellipseMode(CENTER);
   strokeWeight(4);
   stroke(0);
-  if (this.dragging) fill(50);
-  else if (this.rollover) fill(100);
-  else fill(175,200);
-  ellipse(this.position.x,this.position.y,this.mass*2,this.mass*2);
-}
+  if (this.dragging) {
+    fill(50);
+  } else if (this.rollover) {
+    fill(100);
+  } else {
+    fill(175, 200);
+  }
+  ellipse(this.position.x, this.position.y, this.mass*2, this.mass*2);
+};
 
   // The methods below are for mouse interaction
-Attractor.prototype.clicked = function(mx, my) {
-  var d = dist(mx,my,this.position.x,this.position.y);
+Attractor.prototype.handleClick = function(mx, my) {
+  var d = dist(mx, my, this.position.x, this.position.y);
   if (d < this.mass) {
     this.dragging = true;
-    this.dragOffset.x = this.position.x-mx;
-    this.dragOffset.y = this.position.y-my;
+    this.dragOffset.x = this.position.x - mx;
+    this.dragOffset.y = this.position.y - my;
   }
-}
+};
 
-Attractor.prototype.hover = function(mx, my) {
-  var d = dist(mx,my,this.position.x,this.position.y);
+Attractor.prototype.handleHover = function(mx, my) {
+  var d = dist(mx, my, this.position.x, this.position.y);
   if (d < this.mass) {
     this.rollover = true;
   } else {
     this.rollover = false;
   }
-}
+};
 
 Attractor.prototype.stopDragging = function() {
   this.dragging = false;
-}
+};
 
-Attractor.prototype.drag = function() {
+Attractor.prototype.handleDrag = function(mx, my) {
   if (this.dragging) {
-    this.position.x = mouseX + this.dragOffset.x;
-    this.position.y = mouseY + this.dragOffset.y;
+    this.position.x = mx + this.dragOffset.x;
+    this.position.y = my + this.dragOffset.y;
   }
-}
+};

--- a/chp02_forces/NOC_2_7_attraction_many/mover.js
+++ b/chp02_forces/NOC_2_7_attraction_many/mover.js
@@ -2,12 +2,12 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Mover(m,x,y) {
-    this.mass = m;
-    this.position = new PVector(x,y);
-    this.velocity = new PVector(1,0);
-    this.acceleration = new PVector(0,0);
-}
+var Mover = function() {
+  this.position = new PVector(400, 50);
+  this.velocity = new PVector(1, 0);
+  this.acceleration = new PVector(0, 0);
+  this.mass = 1;
+};
   
 Mover.prototype.applyForce = function(force) {
   var f = PVector.div(force,this.mass);
@@ -23,8 +23,8 @@ Mover.prototype.update = function() {
 Mover.prototype.display = function() {
   stroke(0);
   strokeWeight(2);
-  fill(255,127);
-  ellipse(this.position.x,this.position.y,this.mass*16,this.mass*16);
+  fill(255, 127);
+  ellipse(this.position.x, this.position.y, this.mass*16, this.mass*16);
 };
 
 Mover.prototype.checkEdges = function() {
@@ -40,6 +40,3 @@ Mover.prototype.checkEdges = function() {
     this.position.y = height;
   }
 };
-
-
-

--- a/chp02_forces/NOC_2_7_attraction_many/sketch.js
+++ b/chp02_forces/NOC_2_7_attraction_many/sketch.js
@@ -7,33 +7,40 @@ var movers = [];
 var attractor;
 
 function setup() {
-  createGraphics(640,360);
+  createGraphics(640, 360);
   for (var i = 0; i < 10; i++) {
-    movers[i] = new Mover(random(0.1,2),random(width),random(height));
+    movers[i] = new Mover(random(0.1, 2), random(width), random(height));
   }
   attractor = new Attractor();
-};
+}
 
 function draw() {
-  background(51);
+  background(50);
 
   attractor.display();
-  attractor.drag();
-  attractor.hover(mouseX, mouseY);
 
   for (var i = 0; i < movers.length; i++) {
-    var force = attractor.attract(movers[i]);
+    var force = attractor.calculateAttraction(movers[i]);
     movers[i].applyForce(force);
 
     movers[i].update();
     movers[i].display();
   }
-};
+}
+
+function mouseMoved() {
+  attractor.handleHover(mouseX, mouseY);
+}
 
 function mousePressed() {
-  attractor.clicked(mouseX, mouseY);
-};
+  attractor.handlePress(mouseX, mouseY);
+}
+
+function mouseDragged() {
+  attractor.handleHover(mouseX, mouseY);
+  attractor.handleDrag(mouseX, mouseY);
+}
 
 function mouseReleased() {
   attractor.stopDragging();
-};
+}

--- a/chp02_forces/NOC_2_8_mutualattraction/mover.js
+++ b/chp02_forces/NOC_2_8_mutualattraction/mover.js
@@ -2,15 +2,15 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-function Mover(m,x,y) {
-    this.mass = m;
-    this.position = new PVector(x,y);
-    this.velocity = new PVector(0,0);
-    this.acceleration = new PVector(0,0);
-}
+var Mover = function(m, x, y) {
+  this.mass = m;
+  this.position = new PVector(x, y);
+  this.velocity = new PVector(0, 0);
+  this.acceleration = new PVector(0, 0);
+};
   
 Mover.prototype.applyForce = function(force) {
-  var f = PVector.div(force,this.mass);
+  var f = PVector.div(force, this.mass);
   this.acceleration.add(f);
 };
   
@@ -23,20 +23,25 @@ Mover.prototype.update = function() {
 Mover.prototype.display = function() {
   stroke(0);
   strokeWeight(2);
-  fill(255,127);
-  ellipse(this.position.x,this.position.y,this.mass*16,this.mass*16);
+  fill(255, 127);
+  ellipse(this.position.x, this.position.y, this.mass*16, this.mass*16);
 };
 
-Mover.prototype.attract = function(m) {
-  var force = PVector.sub(this.position, m.position);             // Calculate direction of force
-  var distance = force.mag();                                 // Distance between objects
-  distance = constrain(distance, 5.0, 25.0);                             // Limiting the distance to eliminate "extreme" results for very close or very far objects
-  force.normalize();                                            // Normalize vector (distance doesn't matter here, we just want this vector for direction
-
-  var strength = (g * this.mass * m.mass) / (distance * distance); // Calculate gravitional force magnitude
-  force.mult(strength);                                         // Get force vector --> magnitude * direction
+Mover.prototype.calculateAttraction = function(m) {
+  // Calculate direction of force
+  var force = PVector.sub(this.position, m.position);
+  // Distance between objects
+  var distance = force.mag();
+  // Limiting the distance to eliminate "extreme" results for very close or very far objects
+  distance = constrain(distance, 5.0, 25.0);
+  // Normalize vector (distance doesn't matter here, we just want this vector for direction                            
+  force.normalize();
+  // Calculate gravitional force magnitude
+  var strength = (G * this.mass * m.mass) / (distance * distance);
+  // Get force vector --> magnitude * direction
+  force.mult(strength);
   return force;
-  }
+};
 
 
 

--- a/chp02_forces/NOC_2_8_mutualattraction/sketch.js
+++ b/chp02_forces/NOC_2_8_mutualattraction/sketch.js
@@ -5,22 +5,22 @@
 
 var movers = [];
 
-var g = 1;
+var G = 1;
 
 function setup() {
-  createGraphics(640,360);
+  createGraphics(640, 360);
   for (var i = 0; i < 10; i++) {
-    movers[i] = new Mover(random(0.1,2),random(width),random(height)); 
+    movers[i] = new Mover(random(0.1, 2), random(width), random(height));
   }
-};
+}
 
 function draw() {
   background(51);
 
   for (var i = 0; i < movers.length; i++) {
     for (var j = 0; j < movers.length; j++) {
-      if (i != j) {
-        var force = movers[j].attract(movers[i]);
+      if (i !== j) {
+        var force = movers[j].calculateAttraction(movers[i]);
         movers[i].applyForce(force);
       }
     }
@@ -28,4 +28,4 @@ function draw() {
     movers[i].update();
     movers[i].display();
   }
-};
+}


### PR DESCRIPTION
These are mostly style changes, such as:
- Space between parameters in function calls/argument lists
- Semi-colons after function-as-variable statements but not after function blocks
- Removal of trailing whitespace

Note that the last two were caught by my JSHint plugin in SublimeText, which I recommend setting up in your IDE of choice and configuring per agreed upon project conventions.

There were several things I didn't change, despite incompatibility with Khan style:
- I kept function draw(), etc, as blocks instead of statements, per your expressed preference.
- I kept indenting at 2 spaces (we use 4, but 2 spaces appears to be more common nowadays).
- We don't support the 2-argument fill() commands currently, we pop up a message about wrong number of arguments. I could fix that, but I worry some people accidentally use 2 without realizing its an alternate syntax.

I'll make comments inline if there were other things I changed.
