### PR TITLE
Iterate Function Had Parameter but did not use

### DIFF
--- a/chp08_fractals/NOC_8_05_Koch/KochFractal.js
+++ b/chp08_fractals/NOC_8_05_Koch/KochFractal.js
@@ -47,7 +47,7 @@ function KochFractal() {
   this.iterate = function(before) {
     var now = [];    // Create emtpy list
     for(var i = 0; i < before.length; i++) {
-      var l = before.lines[i];
+      var l = before[i];
       // Calculate 5 koch p5.Vectors (done for us by the line object)
       var a = l.kochA();                 
       var b = l.kochB();

--- a/chp08_fractals/NOC_8_05_Koch/KochFractal.js
+++ b/chp08_fractals/NOC_8_05_Koch/KochFractal.js
@@ -46,8 +46,8 @@ function KochFractal() {
   // As we do this over and over again, each line gets broken into 4 lines, which gets broken into 4 lines, and so on. . . 
   this.iterate = function(before) {
     var now = [];    // Create emtpy list
-    for(var i = 0; i < this.lines.length; i++) {
-      var l = this.lines[i];
+    for(var i = 0; i < before.length; i++) {
+      var l = before.lines[i];
       // Calculate 5 koch p5.Vectors (done for us by the line object)
       var a = l.kochA();                 
       var b = l.kochB();


### PR DESCRIPTION
Looks like the iterate function inside KochFractal was set up to use a parameter to pass in the array, however within the function, it called the member array directly. I've updated the function to use parameter.
