### PR TITLE
Removed "location" form "target.location.x" and "target.location.y"

### DIFF
--- a/chp09_ga/NOC_9_03_SmartRockets/rocket.js
+++ b/chp09_ga/NOC_9_03_SmartRockets/rocket.js
@@ -65,7 +65,7 @@ function Rocket(l, dna_, totalRockets) {
 
   // Did I make it to the target?
   this.checkTarget = function() {
-    var d = dist(this.position.x, this.position.y, target.location.x, target.location.y);
+    var d = dist(this.position.x, this.position.y, target.x, target.y);
     if (d < this.recordDist) this.recordDist = d;
 
     if (target.contains(this.position) && !this.hitTarget) {


### PR DESCRIPTION
You fixed this bug yourself in your last youtube video but this repository hasn't change yet.
In case you forgot about it, I'm making this pull request.