### PR TITLE
removed unnecessary <script> tag -- same js file loaded twice

### DIFF
--- a/chp04_systems/NOC_4_05_ParticleSystemInheritancePolymorphism/index.html
+++ b/chp04_systems/NOC_4_05_ParticleSystemInheritancePolymorphism/index.html
@@ -3,7 +3,6 @@
   <title>NOC_4_05_ParticleSystemInheritancePolymorphism</title>
   <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.22/p5.js"></script>
   <script language="javascript" type="text/javascript" src="particle.js"></script>
-  <script language="javascript" type="text/javascript" src="particle_system.js"></script>
   <script language="javascript" type="text/javascript" src="confetti.js"></script>
   <script language="javascript" type="text/javascript" src="particle_system.js"></script>
   <script language="javascript" type="text/javascript" src="sketch.js"></script>


### PR DESCRIPTION
chapter 4 example 5 didn't work when I originally fixed it. Then I saw that I left the out-of-order script tag in the html doc when I fixed it.