### PR TITLE
Bug ReferenceError : println is not defined

### DIFF
--- a/chp00_introduction/Noise1D/sketch.js
+++ b/chp00_introduction/Noise1D/sketch.js
@@ -31,5 +31,5 @@ function draw() {
   fill(200);
   ellipse(x,height/2, 64, 64);
 
-  println(n);
+  print(n);
 }


### PR DESCRIPTION
The example couldn't be run because println is not defined in p5.js